### PR TITLE
feat: allow configuring table count

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,8 @@ UPSTASH_REDIS_REST_TOKEN=your_very_long_token_string_here
 
 # 应用配置
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+# Optional: number of tables (defaults to 24)
+NEXT_PUBLIC_TABLE_COUNT=24
 
 # 注意事项：
 # 1. 将此文件复制为 .env.local 并填入真实值

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ UPSTASH_REDIS_REST_TOKEN=your_very_long_token_string
 
 # 应用配置
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+NEXT_PUBLIC_TABLE_COUNT=24
 ```
 
 > **重要提示**：
@@ -159,6 +160,7 @@ git push origin main
 | `NEXT_PUBLIC_APP_URL` | `https://your-app.vercel.app` | Production |
 | `NEXT_PUBLIC_APP_URL` | `https://your-app-preview.vercel.app` | Preview |
 | `NEXT_PUBLIC_APP_URL` | `http://localhost:3000` | Development |
+| `NEXT_PUBLIC_TABLE_COUNT` | `24` | Production, Preview, Development |
 
 #### 4. 部署
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,7 +10,7 @@ import { ConfirmDeleteModal } from '@/components/ConfirmDeleteModal'
 import { LogsModal } from '@/components/LogsModal'
 import { CoffeeCupIcon, DownloadIcon, HistoryIcon, ArchiveIcon } from '@/components/Icons'
 
-const TABLE_COUNT = 24
+const TABLE_COUNT = parseInt(process.env.NEXT_PUBLIC_TABLE_COUNT || '24', 10)
 
 export default function HomePage() {
   const [orders, setOrders] = useState<Order[]>([])


### PR DESCRIPTION
## Summary
- allow configuring table count via NEXT_PUBLIC_TABLE_COUNT env variable
- document table count setting in environment examples

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1cd3399108328ae98bc8314fc47a5